### PR TITLE
Allow customizing of container element

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -220,6 +220,25 @@ Example:
 )
 ```
 
+### Form with Custom view
+Especially when working with [custom field views](basicfields---custom-views), it may be beneficial, to also use a custom container element. 
+
+By default, the render function places all fields in a `div` element. When using `BuildWithCustomView` instead of `Build()` during form creation, a custom view function can be provided. This allows using any other fitting function (like `form`) or using a custom function that may return a `div` element with custom css-classes or even customize the contents.
+
+Example:
+```fsharp
+let formView attributes children = div attributes (children |> Seq.rev)
+
+let (formState, formConfig) =
+    Form<Msg>
+        .Create(OnFormMsg)
+        .AddField(xy..)
+        // instead of using `.Build()`, we provide our own view function:
+        .BuildWithCustomView formView
+```
+
+When combined with [custom fields](create-a-custom-field), this allows complex form layouts. But be carefull, with the given parameters - the actual attributes and children are considered an implementation detail that may change without notice (like the nesting of child elements for example).
+
 ### Server side validation
 
 In order to support server side validation, the library defines the type `ErrorDef`.

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -2,6 +2,7 @@ namespace Thoth.Elmish.FormBuilder
 
 open Thoth.Json
 open Fable.React
+open Fable.React.Props
 open Elmish
 
 module Types =
@@ -83,7 +84,8 @@ module Types =
     /// Configuration for the Form
     type Config<'AppMsg> =
         { ToMsg : Msg -> 'AppMsg
-          FieldsConfig : Map<FieldType, FieldConfig> }
+          FieldsConfig : Map<FieldType, FieldConfig>
+          View: (IHTMLProp seq -> ReactElement seq -> ReactElement) }
 
     type FieldBuilder =
         { Type : FieldType


### PR DESCRIPTION
I'm looking for ways to support custom layouts (like Flexgird or even more complex views) - something that cannot be achieved with custom fields only. At least, I was unable to do so because of missing control over the fields container  element.

So I've added a possibility to replace the form view with a custom component (without adding breaking changes).

Is this a possible solution or should I try other routes? Do you accept merge requests for this at all? Please let me know, when anything needs adjustment to be merged.

This might close #11.